### PR TITLE
Updating Analysis Module to new LArG4

### DIFF
--- a/larexamples/AnalysisExample/AnalysisExample.fcl
+++ b/larexamples/AnalysisExample/AnalysisExample.fcl
@@ -3,8 +3,8 @@
 # particular, in this script there are no output streams because the
 # module doesn't write any events, just histograms or n-tuples.
 
-# See <https://cdcvs.fnal.gov/redmine/projects/larsoft/wiki/_Running_Jobs_> 
-# for more information on the structure of .fcl files. 
+# See <https://cdcvs.fnal.gov/redmine/projects/larsoft/wiki/_Running_Jobs_>
+# for more information on the structure of .fcl files.
 
 # The following line has to be changed to match your experiment; e.g.,
 # "services_dune.fcl", "services_lariat.fcl". I'm using microboone
@@ -71,8 +71,8 @@ source:
   module_type: RootInput
 
   # Number of events to analyze; "-1" means all of the events in the input
-  # file. You can override this value with the "-n" option on the command line. 
-  maxEvents:  -1 
+  # file. You can override this value with the "-n" option on the command line.
+  maxEvents:  -1
 
   # I've commented this out, but if you want to include the name of
   # an art::Event input file in a script, here's how you do it.
@@ -91,9 +91,9 @@ physics:
   # Define the variables we'll need to read for this analysis program.
   analyzers:
   {
-    # This name defines a job step below, and will appear as a directory 
-    # in the output histogram file. 
-    AnalysisExample: 
+    # This name defines a job step below, and will appear as a directory
+    # in the output histogram file.
+    AnalysisExample:
     {
       # The "module_type" tells us which module to run. The name here
       # must match the name supplied to DEFINE_ART_MODULE near the end
@@ -116,6 +116,13 @@ physics:
 
       SimulationLabel: "largeant"
 
+      # After the larg4 refactorization, the largeant module mentioned
+      # above does not produce SimChannel products anymore and another
+      # label is needed (still largeant as default here for backwards
+      # compatibility)
+
+      SimChannelLabel: "largeant"
+
       # Hits can be created by more than one module in
       # ${LARRECO_DIR}/source/larreco/HitFinder. For this example, I
       # picked the one that's usually run first.
@@ -130,7 +137,7 @@ physics:
       # PDG code 13 = mu-.
       PDGcode:          13
 
-      # dx used for the dE/dx calculation; units are cm. 
+      # dx used for the dE/dx calculation; units are cm.
       BinSize:          0.3
     }
   }

--- a/larexamples/AnalysisExample/AnalysisExample_module.cc
+++ b/larexamples/AnalysisExample/AnalysisExample_module.cc
@@ -253,12 +253,13 @@ namespace lar::example {
     // The parameters we'll read from the .fcl file.
     art::InputTag fSimulationProducerLabel; ///< The name of the producer that tracked
                                             ///< simulated particles through the detector
-    art::InputTag fSimChannelProducerLabel; ///< The name of the producer that created wire information
-    art::InputTag fHitProducerLabel;        ///< The name of the producer that created hits
-    art::InputTag fClusterProducerLabel;    ///< The name of the producer that
-                                            ///< created clusters
-    int fSelectedPDG;                       ///< PDG code of particle we'll focus on
-    double fBinSize;                        ///< For dE/dx work: the value of dx.
+    art::InputTag
+      fSimChannelProducerLabel;          ///< The name of the producer that created wire information
+    art::InputTag fHitProducerLabel;     ///< The name of the producer that created hits
+    art::InputTag fClusterProducerLabel; ///< The name of the producer that
+                                         ///< created clusters
+    int fSelectedPDG;                    ///< PDG code of particle we'll focus on
+    double fBinSize;                     ///< For dE/dx work: the value of dx.
 
     // Pointers to the histograms we'll create.
     TH1D* fPDGCodeHist;     ///< PDG code of all particles

--- a/larexamples/AnalysisExample/AnalysisExample_module.cc
+++ b/larexamples/AnalysisExample/AnalysisExample_module.cc
@@ -20,7 +20,7 @@
  * Also note that, despite our efforts, the documentation and the practices in this code
  * may fall out of date. In doubt, ask!
  *
- * The last revision of this code was done in August 2017 with LArSoft v06_44_00.
+ * The last revision of this code was done in June 2026 with LArSoft v10_20_08 to accommodate larg4 refactorization
  *
  * This is in-source documentation in Doxygen format. Doxygen is a utility that creates
  * web pages from specially-formatted comments in program code. If your package is ever
@@ -145,6 +145,11 @@ namespace lar::example {
    *   product with the detector simulation information (typically an instance
    *   of the LArG4 module)
    *
+   * - *SimChannelLabel* (string, default: "largeant"): tag of the input data
+   *   product with the wire simulation information. PS: this default label
+   *   will fail for anything run after the larg4 refactorization but can be
+   *   adjusted in the running fhicl file
+   *
    * - *HitLabel* (string, mandatory): tag of the input data product with
    *   reconstructed hits
    *
@@ -184,6 +189,11 @@ namespace lar::example {
       fhicl::Atom<art::InputTag> SimulationLabel{
         Name("SimulationLabel"),
         Comment("tag of the input data product with the detector simulation "
+                "information")};
+
+      fhicl::Atom<art::InputTag> SimChannelLabel{
+        Name("SimChannelLabel"),
+        Comment("tag of the input data product with wire simulation "
                 "information")};
 
       fhicl::Atom<art::InputTag> HitLabel{
@@ -243,6 +253,7 @@ namespace lar::example {
     // The parameters we'll read from the .fcl file.
     art::InputTag fSimulationProducerLabel; ///< The name of the producer that tracked
                                             ///< simulated particles through the detector
+    art::InputTag fSimChannelProducerLabel; ///< The name of the producer that created wire information
     art::InputTag fHitProducerLabel;        ///< The name of the producer that created hits
     art::InputTag fClusterProducerLabel;    ///< The name of the producer that
                                             ///< created clusters
@@ -324,6 +335,7 @@ namespace lar::example {
   AnalysisExample::AnalysisExample(Parameters const& config)
     : EDAnalyzer(config)
     , fSimulationProducerLabel(config().SimulationLabel())
+    , fSimChannelProducerLabel(config().SimChannelLabel())
     , fHitProducerLabel(config().HitLabel())
     , fClusterProducerLabel(config().ClusterLabel())
     , fSelectedPDG(config().PDGcode())
@@ -341,7 +353,7 @@ namespace lar::example {
     // ("may_consume"). Diligence here will in the future help the framework execute
     // modules in parallel, making sure the order is correct.
     consumes<std::vector<simb::MCParticle>>(fSimulationProducerLabel);
-    consumes<std::vector<sim::SimChannel>>(fSimulationProducerLabel);
+    consumes<std::vector<sim::SimChannel>>(fSimChannelProducerLabel);
     consumes<art::Assns<simb::MCTruth, simb::MCParticle>>(fSimulationProducerLabel);
     consumes<std::vector<recob::Hit>>(fHitProducerLabel);
     consumes<std::vector<recob::Cluster>>(fClusterProducerLabel);
@@ -463,7 +475,7 @@ namespace lar::example {
     // exception.
 
     auto simChannelHandle =
-      event.getValidHandle<std::vector<sim::SimChannel>>(fSimulationProducerLabel);
+      event.getValidHandle<std::vector<sim::SimChannel>>(fSimChannelProducerLabel);
 
     //
     // Let's compute the variables for the simulation n-tuple first.


### PR DESCRIPTION
After the refactorization of LArG4, the old largeant module was split. With this, two different labels for products are needed: one for the producer that ran the simulation module and another one for the producer of the SimChannel product.